### PR TITLE
patch duration calculation for (Single)Bar 're-start' scenario

### DIFF
--- a/lib/generic-bar.js
+++ b/lib/generic-bar.js
@@ -119,6 +119,9 @@ module.exports = class GenericBar extends _EventEmitter{
         // store start time for duration+eta calculation
         this.startTime = Date.now();
 
+        // reset stop time for 're-start' scenario (used for duration calculation)
+        this.stopTime = null;
+
         // reset string line buffer (redraw detection)
         this.lastDrawnString = '';
 
@@ -138,7 +141,7 @@ module.exports = class GenericBar extends _EventEmitter{
         this.isActive = false;
         
         // store stop timestamp to get total duration
-        this.stopTime = new Date();
+        this.stopTime = Date.now();
 
         // stop event
         this.emit('stop', this.total, this.value);


### PR DESCRIPTION
In my use-case I am periodically stopping and re-starting the SingleBar to track the overall progress of my application.
Thus, I found out that the duration calculation is not working properly and so I provide here an easy fix (plus a minor data type correction).

Note: I have not tested this with MultiBar mode.